### PR TITLE
Allow this client to be Node package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export {UFDLServerContext as Server} from "./src/ufdl/context.js";

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ufdl-js-client",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "A JavaScript client to connect the UFDL web frontend to the backend.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/waikato-ufdl/ufdl-js-client.git"
+  },
+  "keywords": [
+    "UFDL",
+    "JS",
+    "client"
+  ],
+  "author": "Waikato UFDL",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/waikato-ufdl/ufdl-js-client/issues"
+  },
+  "homepage": "https://github.com/waikato-ufdl/ufdl-js-client#readme"
+}


### PR DESCRIPTION
This commit initialises the JavaScript client so that it can be
installed as a package using "npm install". This is useful for other
projects that use NodeJS or NPM and depend on this client. Specific
functionality can be exported in the "index.js" file, which currently
allows access to the UFDLServerContext class.